### PR TITLE
fix: breadcrumb isCurrent disabled should be false

### DIFF
--- a/src/breadcrumbs/BreadcrumbLink.ts
+++ b/src/breadcrumbs/BreadcrumbLink.ts
@@ -20,10 +20,6 @@ export const useBreadcrumbLink = createHook<
   compose: useLink,
   keys: BREADCRUMB_LINK_KEYS,
 
-  useOptions(options) {
-    return { disabled: options.disabled || options.isCurrent, ...options };
-  },
-
   useProps({ isCurrent }, htmlProps) {
     return { "aria-current": isCurrent && "page", ...htmlProps };
   },

--- a/src/breadcrumbs/__tests__/Breadcrumbs.test.tsx
+++ b/src/breadcrumbs/__tests__/Breadcrumbs.test.tsx
@@ -65,10 +65,7 @@ describe("Breadcrumb", () => {
               <li>
                 <a
                   aria-current="page"
-                  aria-disabled="true"
                   href="https://www.w3.org/TR/wai-aria-practices-1.1/#breadcrumb"
-                  style="pointer-events: none;"
-                  tabindex="-1"
                 >
                   Breadcrumb Pattern
                 </a>


### PR DESCRIPTION
aria-current=page should not have be disabled, since it would prevent it from being tabbable and voice assistants won't announce it either.

![image](https://user-images.githubusercontent.com/35374649/95047493-cc5ee700-0703-11eb-9edd-98a9866bb0f1.png)

https://www.w3.org/TR/wai-aria-practices-1.1/#breadcrumb